### PR TITLE
Add support for test.serial

### DIFF
--- a/src/ava-fast-check.ts
+++ b/src/ava-fast-check.ts
@@ -55,6 +55,12 @@ export namespace testProp {
     prop: Prop<Ts>,
     params?: fc.Parameters<Ts>
   ): void => internalTestProp(test.skip, label, arbitraries, prop, params);
+  export const serial = <Ts extends any[]>(
+    label: string,
+    arbitraries: ArbitraryTuple<Ts>,
+    prop: Prop<Ts>,
+    params?: fc.Parameters<Ts>
+  ): void => internalTestProp(test.serial, label, arbitraries, prop, params);
 }
 
 export { test, fc };

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,8 @@ for expectedContent in \
         "not ok 7 - should fail as the property passes" \
         "ok 8 - should never be executed (with seed=48) # SKIP" \
         "ok 9 - should run first" \
-        "ok 10 - should run after"
+        "ok 10 - should run after" \
+        "ok 11 - should run serially"
 do
     cat test/out.log | grep "${expectedContent}" >/dev/null 2>&1
     if [ $? -ne 0 ]; then

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,9 @@ for expectedContent in \
         "not ok 5 - should fail with seed=4242 and path=\"25\" (with seed=4242)" "seed: 4242, path: \"25\"" \
         "ok 6 - should pass as the property fails" \
         "not ok 7 - should fail as the property passes" \
-        "ok 8 - should never be executed (with seed=48) # SKIP"
+        "ok 8 - should never be executed (with seed=48) # SKIP" \
+        "ok 9 - should run first" \
+        "ok 10 - should run after"
 do
     cat test/out.log | grep "${expectedContent}" >/dev/null 2>&1
     if [ $? -ne 0 ]; then

--- a/test/testProp.js
+++ b/test/testProp.js
@@ -29,3 +29,14 @@ testProp.failing('should fail as the property passes', [fc.boolean()], a => a ||
 // testProp.skip
 
 testProp.skip('should never be executed', [fc.boolean()], a => a, { seed: 48 });
+
+// testProp.serial
+let serialRun = false;
+testProp.serial("should run first", [fc.boolean()], async a => {
+  serialRun = true;
+  await delay(0);
+  return a == a;
+});
+testProp.serial("should run after", [fc.boolean()], async a => {
+  return a == a && serialRun;
+});

--- a/test/testProp.js
+++ b/test/testProp.js
@@ -31,6 +31,8 @@ testProp.failing('should fail as the property passes', [fc.boolean()], a => a ||
 testProp.skip('should never be executed', [fc.boolean()], a => a, { seed: 48 });
 
 // testProp.serial
+
+// Test that one serial run is after the other
 let serialRun = false;
 testProp.serial("should run first", [fc.boolean()], async a => {
   serialRun = true;
@@ -39,4 +41,12 @@ testProp.serial("should run first", [fc.boolean()], async a => {
 });
 testProp.serial("should run after", [fc.boolean()], async a => {
   return a == a && serialRun;
+});
+
+// Test that each execution of a test is run serially (and in order)
+let runs = 0;
+testProp.serial("should run serially", [fc.boolean()], async a => {
+  let run = runs++;
+  delay(a ? 1 : 0);
+  return a == a && runs == (run + 1);
 });


### PR DESCRIPTION
I've added support for Ava's `test.serial()` as it would be useful for my tests.