### PR TITLE
feat: allow statically-typed ava execution context

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![Build Status](https://travis-ci.com/dubzzz/ava-fast-check.svg?branch=master)](https://travis-ci.com/dubzzz/ava-fast-check)
 [![npm version](https://badge.fury.io/js/ava-fast-check.svg)](https://badge.fury.io/js/ava-fast-check)
 
-Bring the power of property based testing framework fast-check into ava.
-`ava-fast-check` simplifies the integration of fast-check into ava testing framework.
+Bring the power of property based testing framework fast-check into AVA.
+`ava-fast-check` simplifies the integration of fast-check into AVA testing framework.
 
-## Getting started
+## Getting Started
 
 Install `ava-fast-check` and its peer dependencies:
 
@@ -16,7 +16,7 @@ npm install --save-dev ava fast-check ava-fast-check
 
 ## Example
 
-```javascript
+```typescript
 import { testProp, fc } from 'ava-fast-check';
 
 // for all a, b, c strings
@@ -26,31 +26,88 @@ testProp('should detect the substring', [fc.string(), fc.string(), fc.string()],
 });
 ```
 
-The property is passed [`ava`'s `t` argument](https://github.com/avajs/ava/blob/master/docs/02-execution-context.md#execution-context-t-argument) for its first parameter, and the value of each arbitrary for the current test case for the rest of the parameters.
+The property is passed [AVA's `t` argument](https://github.com/avajs/ava/blob/master/docs/02-execution-context.md#execution-context-t-argument) for its first parameter, and the value of each arbitrary for the current test case for the rest of the parameters.
 
-`ava-fast-check` supports all of [`ava`'s assertions](https://github.com/avajs/ava/blob/master/docs/03-assertions.md#assertions) and like `ava`, supports synchronous and asynchronous functions, including promises, observables, and callbacks. See [`ava`'s documentation](https://github.com/avajs/ava/blob/master/docs/01-writing-tests.md#declaring-test) for more information.
+`ava-fast-check` supports all of [AVA's assertions](https://github.com/avajs/ava/blob/master/docs/03-assertions.md#assertions) and like AVA, supports synchronous and asynchronous functions, including promises, observables, and callbacks. See [AVA's documentation](https://github.com/avajs/ava/blob/master/docs/01-writing-tests.md#declaring-test) for more information.
 
 ## Advanced
 
-If you want to forward custom parameters to fast-check, `testProp` accepts an optional `fc.Parameters` ([more](https://github.com/dubzzz/fast-check/blob/master/documentation/Runners.md#runners)).
+### `fast-check` Parameters
 
-`ava-fast-check` also comes with `.only`, `.skip` and `.failing` from `ava`.
+`testProp` accepts an optional `fc.Parameters` for forwarding custom parameters to `fast-check` ([more](https://github.com/dubzzz/fast-check/blob/master/documentation/Runners.md#runners)).
 
-```javascript
+### AVA Modifiers
+
+`ava-fast-check` also comes with [`.only`], [`.serial`] [`.skip`], and [`.failing`] modifiers from AVA.
+
+```typescript
 import { testProp, fc } from 'ava-fast-check';
 
 testProp('should replay the test for the seed 4242', [fc.nat(), fc.nat()], (t, a, b) => {
   t.is(a + b, b + a);
 }, { seed: 4242 });
 
-testProp.failing('should be skipped', [fc.fullUnicodeString()], (t, text) => {
+testProp.skip('should be skipped', [fc.fullUnicodeString()], (t, text) => {
   t.is([...text].length, text.length);
 });
 ```
 
+[`.only`]: https://github.com/avajs/ava/blob/master/docs/01-writing-tests.md#running-specific-tests
+[`.serial`]: https://github.com/avajs/ava/blob/master/docs/01-writing-tests.md#running-tests-serially
+[`.skip`]: https://github.com/avajs/ava/blob/master/docs/01-writing-tests.md#skipping-tests
+[`.failing`]: https://github.com/avajs/ava/blob/master/docs/01-writing-tests.md#failing-tests
+
+### AVA `before`/`after` Hooks
+
+Import `test` from `ava-fast-check` to use `before`/`after` [hooks]:
+
+```typescript
+import { test, testProp, fc } from 'ava-fast-check';
+
+test.before(t => {
+  connectToDatabase();
+});
+
+testProp(
+  // ... omitted for brevity
+);
+
+test.after(t => {
+  closeDatabaseConnection();
+});
+```
+
+[hooks]: https://github.com/avajs/ava/blob/master/docs/01-writing-tests.md#before--after-hooks
+
+### AVA Execution Context
+
+`ava-fast-check` mirror's AVA's procedure for customizing the test [execution context]:
+
+```typescript
+import { fc, testProp as anyTestProp, PropertyTestInterface } from '../src/ava-fast-check';
+
+type TestContext = {
+  state: string
+};
+
+const testProp = anyTestProp as PropertyTestInterface<TestContext>;
+
+testProp(
+  'should reach terminal state',
+  [fc.string()],
+  (t, received) => {
+    // here t is typed as ExecutionContext<TestContext>
+    console.log(t.context.state); // logs 'uninitialized'
+    // ... omitted for brevity
+  }
+);
+```
+
+[execution context]: https://github.com/avajs/ava/blob/master/docs/02-execution-context.md
+
 ## Minimal requirements
 
-| ava-fast-check | ava                   | fast-check           |
+| ava-fast-check | AVA                   | fast-check           |
 |----------------|-----------------------|----------------------|
 | ^3.0.0         | >=3.9.0<sup>(1)</sup> | ^2.0.0<sup>(2)</sup> |
 | ^2.0.0         | >=3.9.0<sup>(1)</sup> | ^1.0.0               |

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ testProp.skip('should be skipped', [fc.fullUnicodeString()], (t, text) => {
 
 ### AVA `before`/`after` Hooks
 
-Import `test` from `ava-fast-check` to use `before`/`after` [hooks]:
+`ava-fast-check` exposes AVA's `before`/`after` [hooks]:
 
 ```typescript
-import { test, testProp, fc } from 'ava-fast-check';
+import { testProp, fc } from 'ava-fast-check';
 
-test.before(t => {
+testProp.before(t => {
   connectToDatabase();
 });
 
@@ -72,7 +72,7 @@ testProp(
   // ... omitted for brevity
 );
 
-test.after(t => {
+testProp.after(t => {
   closeDatabaseConnection();
 });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2299,9 +2299,9 @@
       "dev": true
     },
     "ts-node": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.0.0.tgz",
+      "integrity": "sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
@@ -2309,18 +2309,6 @@
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.17",
         "yn": "3.1.1"
-      },
-      "dependencies": {
-        "source-map-support": {
-          "version": "0.5.19",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        }
       }
     },
     "type-fest": {
@@ -2339,9 +2327,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
-      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "esm": "^3.2.25",
     "fast-check": "^2.0.0",
     "prettier": "^1.19.1",
-    "ts-node": "^8.10.2",
-    "typescript": "^3.9.6"
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.3"
   },
   "keywords": [
     "ava",

--- a/src/ava-fast-check.ts
+++ b/src/ava-fast-check.ts
@@ -1,4 +1,6 @@
 import test, {
+  AfterInterface,
+  BeforeInterface,
   ExecutionContext,
   Implementation,
   ImplementationResult,
@@ -11,9 +13,9 @@ export { fc, test };
 
 type NonEmptyArray<A> = A[] & {0: A};
 
-// Pre-requisite: https://github.com/Microsoft/TypeScript/pull/26063
-// Require TypeScript 3.1
-type ArbitraryTuple<Ts extends NonEmptyArray<any>> = { [P in keyof Ts]: fc.Arbitrary<Ts[P]> };
+type ArbitraryTuple<Ts extends NonEmptyArray<any>> = {
+  [P in keyof Ts]: fc.Arbitrary<Ts[P]>
+};
 
 type Prop<Context, Ts extends NonEmptyArray<any>> = (
   t: ExecutionContext<Context>,
@@ -33,9 +35,13 @@ type AvaModifierWhitelist =
   | 'skip'
   | 'serial'
 
-export type PropertyTestInterface<Context> = PropertyTest<Context> & {
-  [Modifier in AvaModifierWhitelist]: PropertyTest<Context>;
-}
+export type PropertyTestInterface<Context> =
+  & PropertyTest<Context>
+  & { [Modifier in AvaModifierWhitelist]: PropertyTest<Context> }
+  & {
+    before: BeforeInterface<Context>,
+    after: AfterInterface<Context>,
+  }
 
 function wrapProp<Context, Ts extends NonEmptyArray<any>>(
   arbitraries: ArbitraryTuple<Ts>,
@@ -102,6 +108,8 @@ export const testProp: PropertyTestInterface<unknown> = Object.assign(
     only: exposeModifier('only'),
     failing: exposeModifier('failing'),
     skip: exposeModifier('skip'),
-    serial: exposeModifier('serial')
+    serial: exposeModifier('serial'),
+    before: test.before,
+    after: test.after,
   }
-)
+);

--- a/src/ava-fast-check.ts
+++ b/src/ava-fast-check.ts
@@ -1,17 +1,47 @@
-import test, { ExecutionContext, Implementation, ImplementationResult, TryResult } from 'ava';
+import test, {
+  ExecutionContext,
+  Implementation,
+  ImplementationResult,
+  TestInterface,
+  TryResult
+} from 'ava';
 import * as fc from 'fast-check';
+
+export { fc, test };
+
+type NonEmptyArray<A> = A[] & {0: A};
 
 // Pre-requisite: https://github.com/Microsoft/TypeScript/pull/26063
 // Require TypeScript 3.1
-type ArbitraryTuple<Ts extends [any] | any[]> = { [P in keyof Ts]: fc.Arbitrary<Ts[P]> };
+type ArbitraryTuple<Ts extends NonEmptyArray<any>> = { [P in keyof Ts]: fc.Arbitrary<Ts[P]> };
 
-type Prop<Ts extends [any] | any[]> = (t: ExecutionContext, ...args: Ts) => ImplementationResult;
+type Prop<Context, Ts extends NonEmptyArray<any>> = (
+  t: ExecutionContext<Context>,
+  ...args: Ts
+) => ImplementationResult;
 
-function wrapProp<Ts extends [any] | any[]>(
+type PropertyTest<Context> = <Ts extends NonEmptyArray<any>>(
+  label: string,
   arbitraries: ArbitraryTuple<Ts>,
-  prop: Prop<Ts>,
+  prop: Prop<Context, Ts>,
   params?: fc.Parameters<Ts>
-): Implementation {
+) => void;
+
+type AvaModifierWhitelist =
+  | 'only'
+  | 'failing'
+  | 'skip'
+  | 'serial'
+
+export type PropertyTestInterface<Context> = PropertyTest<Context> & {
+  [Modifier in AvaModifierWhitelist]: PropertyTest<Context>;
+}
+
+function wrapProp<Context, Ts extends NonEmptyArray<any>>(
+  arbitraries: ArbitraryTuple<Ts>,
+  prop: Prop<Context, Ts>,
+  params?: fc.Parameters<Ts>
+): Implementation<Context> {
   return async t => {
     let failingTry: undefined | TryResult;
 
@@ -39,11 +69,11 @@ function wrapProp<Ts extends [any] | any[]>(
   };
 }
 
-function internalTestProp<Ts extends [any] | any[]>(
-  testFn: (label: string, exec: Implementation) => void,
+function internalTestProp<Context, Ts extends NonEmptyArray<any>>(
+  testFn: (label: string, exec: Implementation<Context>) => void,
   label: string,
   arbitraries: ArbitraryTuple<Ts>,
-  prop: Prop<Ts>,
+  prop: Prop<Context, Ts>,
   params?: fc.Parameters<Ts>
 ): void {
   const customParams: fc.Parameters<Ts> = params || {};
@@ -52,40 +82,26 @@ function internalTestProp<Ts extends [any] | any[]>(
   testFn(`${label} (with seed=${customParams.seed})`, wrapProp(arbitraries, prop, params));
 }
 
-export function testProp<Ts extends [any] | any[]>(
-  label: string,
-  arbitraries: ArbitraryTuple<Ts>,
-  prop: Prop<Ts>,
-  params?: fc.Parameters<Ts>
-): void {
-  internalTestProp(test, label, arbitraries, prop, params);
+function exposeModifier<Context, T extends Extract<keyof TestInterface, AvaModifierWhitelist>>(
+  modifier: T
+): PropertyTest<Context> {
+  return (label, arbitraries, prop, params) =>
+    internalTestProp((test as TestInterface<Context>)[modifier], label, arbitraries, prop, params);
 }
 
-export namespace testProp {
-  export const only = <Ts extends [any] | any[]>(
+export const testProp: PropertyTestInterface<unknown> = Object.assign(
+  function testProp<Context, Ts extends NonEmptyArray<any>>(
     label: string,
     arbitraries: ArbitraryTuple<Ts>,
-    prop: Prop<Ts>,
+    prop: Prop<Context, Ts>,
     params?: fc.Parameters<Ts>
-  ): void => internalTestProp(test.only, label, arbitraries, prop, params);
-  export const failing = <Ts extends [any] | any[]>(
-    label: string,
-    arbitraries: ArbitraryTuple<Ts>,
-    prop: Prop<Ts>,
-    params?: fc.Parameters<Ts>
-  ): void => internalTestProp(test.failing, label, arbitraries, prop, params);
-  export const skip = <Ts extends [any] | any[]>(
-    label: string,
-    arbitraries: ArbitraryTuple<Ts>,
-    prop: Prop<Ts>,
-    params?: fc.Parameters<Ts>
-  ): void => internalTestProp(test.skip, label, arbitraries, prop, params);
-  export const serial = <Ts extends [any] | any[]>(
-    label: string,
-    arbitraries: ArbitraryTuple<Ts>,
-    prop: Prop<Ts>,
-    params?: fc.Parameters<Ts>
-  ): void => internalTestProp(test.serial, label, arbitraries, prop, params);
-}
-
-export { test, fc };
+  ): void {
+    internalTestProp(test as TestInterface<Context>, label, arbitraries, prop, params);
+  },
+  {
+    only: exposeModifier('only'),
+    failing: exposeModifier('failing'),
+    skip: exposeModifier('skip'),
+    serial: exposeModifier('serial')
+  }
+)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,10 @@
     "compilerOptions": {
         "declaration": true,
         "sourceMap": false,
+        "strict": true,
         "alwaysStrict": true,
-        "noImplicitAny": true,
-        "noImplicitThis": true,
         "removeComments": true,
         "preserveConstEnums": true,
-        "strictNullChecks": true,
         "downlevelIteration": true,
         "module": "commonjs",
         "target": "es3",


### PR DESCRIPTION
There are numerous changes to this PR, broken down by file

- ava-fast-check.ts
  - add type parameter `Context` representing AVA's `ExecutionContext`
    - this allows users to access a statically-typed `ExecutionContext`
      in TypeScript
  - [avoid use of namespace](https://michelenasti.com/2019/01/23/is-typescript-namespace-feature-deprecated.html)
    -  instead export a function with properties as a [hybrid type](https://www.typescriptlang.org/docs/handbook/interfaces.html#hybrid-types)
    - this allows us to thread a typed ExecutionContext through all
      exposed modifiers
  - create function `exposeModifier` to reduce boilerplace in exposing
    ava modifiers
  - Define type `NonEmptyArray`, which I assume is what the previous
    type `[any] | any[]` was trying to enforce, although that type
    can be reduced to `any[]` and thus is not equivalent
    - this pushes what used to be a runtime error (specifying zero
      arbitraries: `asyncProperty expects at least two parameters`)
      to be a compilation error instead
  - export `before`/`beforeEach`/`after`/`afterEach` hooks through `testProp`
    -  In the case where the user supplies his own `ExecutionContext` as well
       as before/after hooks, this means the user only needs to set the
       `ExecutionContext` with a type assertion one time (on `testProp`) rather
       than on `testProp` and on the AVA `test`

- tsconfig.json
  - use `strict: true`
  - remove flags specified as a part of `strict: true`

- package.json
  - bump `typescript` version to 4.0.3
  - bump `ts-node` version to 9.0.0

- README.md
  - use uppercase AVA rather than ava or `ava` for consistency with AVA
    documentation
  - document that `serial` modifier is exposed through `ava-fast-check`
  - document that `before`/`after` hooks are supported with example
  - document new statically-typed Execution Context with example

**Note**: I did not bump the version number or create a git tag for release. 
I would not consider the change to `NonEmptyArray` a breaking change since
what is now a compilation error was already a runtime error. 

Closes #15